### PR TITLE
rename the maven artifacts to camunda-8- from camunda-cloud-

### DIFF
--- a/dmn-java-springboot/pom.xml
+++ b/dmn-java-springboot/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.camunda.community.examples</groupId>
-	<artifactId>camunda-cloud-dmn</artifactId>
+	<artifactId>camunda-8-dmn</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>

--- a/twitter-review-java-springboot/pom.xml
+++ b/twitter-review-java-springboot/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.camunda.community.examples</groupId>
-	<artifactId>camunda-cloud-twitter-review</artifactId>
+	<artifactId>camunda-8-twitter-review</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>


### PR DESCRIPTION
These two useful project appeared in my Eclipse as camunda-cloud-. With the change, they become camunda-8- and I can remember them more easily.