### PR TITLE
feat(zeebe-client): add standalone decision evaluation example

### DIFF
--- a/zeebe-client-plain-java/pom.xml
+++ b/zeebe-client-plain-java/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>zeebe-client-java</artifactId>
-            <version>8.2.0-SNAPSHOT</version>
+            <version>8.2.0-alpha4</version>
         </dependency>
 
         <dependency>

--- a/zeebe-client-plain-java/pom.xml
+++ b/zeebe-client-plain-java/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>zeebe-client-java</artifactId>
-            <version>8.1.2</version>
+            <version>8.2.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/decision/EvaluateDecisionCreator.java
+++ b/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/decision/EvaluateDecisionCreator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.example.decision;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+
+/**
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
+public final class EvaluateDecisionCreator {
+
+  public static void main(final String[] args) {
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
+
+    final ZeebeClientBuilder clientBuilder;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
+
+    final String decisionId = "demoDecision_jedi_or_sith";
+
+    try (final ZeebeClient client = clientBuilder.build()) {
+
+      System.out.println("Evaluating decision");
+
+      final EvaluateDecisionResponse decisionEvaluation =
+          client
+              .newEvaluateDecisionCommand()
+              .decisionId(decisionId)
+              .variables("{\"lightsaberColor\": \"blue\"}")
+              .send()
+              .join();
+
+      System.out.println(
+          "Decision evaluation result: " + decisionEvaluation.getDecisionOutput());
+    }
+  }
+}

--- a/zeebe-client-plain-java/src/main/resources/demoDecision.dmn
+++ b/zeebe-client-plain-java/src/main/resources/demoDecision.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="demoDecision_jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/zeebe-client-plain-java/src/test/java/io/camunda/zeebe/example/DocsConsistencyTest.java
+++ b/zeebe-client-plain-java/src/test/java/io/camunda/zeebe/example/DocsConsistencyTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.example.cluster.TopologyViewer;
 import io.camunda.zeebe.example.data.HandleVariablesAsPojo;
+import io.camunda.zeebe.example.decision.EvaluateDecisionCreator;
 import io.camunda.zeebe.example.job.JobWorkerCreator;
 import io.camunda.zeebe.example.process.NonBlockingProcessInstanceCreator;
 import io.camunda.zeebe.example.process.ProcessDeployer;
@@ -44,6 +45,7 @@ public final class DocsConsistencyTest {
           {ProcessDeployer.class, "io.camunda.zeebe.example.process.ProcessDeployer"},
           {ProcessInstanceCreator.class, "io.camunda.zeebe.example.process.ProcessInstanceCreator"},
           {HandleVariablesAsPojo.class, "io.camunda.zeebe.example.data.HandleVariablesAsPojo"},
+          {EvaluateDecisionCreator.class, "io.camunda.zeebe.example.decision.EvaluateDecisionCreator"},
         });
   }
 


### PR DESCRIPTION
Add an example for standalone decision evaluation in the `zeebe-client-plain-java` module.

:information_source: The PR also bumps the Zeebe version to `8.2.0-alpha4`.

Contributed as part of https://github.com/camunda/camunda-platform-docs/issues/1516