### PR TITLE
Provide example on how to use Authentication provider to build a Zeebe Client

### DIFF
--- a/zeebe-client-plain-java/pom.xml
+++ b/zeebe-client-plain-java/pom.xml
@@ -27,14 +27,8 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.2</version>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.20.0</version>
         </dependency>
 
         <dependency>

--- a/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/authorization/AuthorizationProvider.java
+++ b/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/authorization/AuthorizationProvider.java
@@ -1,0 +1,72 @@
+package io.camunda.zeebe.example.authorization;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProvider;
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+
+
+/**
+ * Example application that connects to a locally deployed cluster.
+ * When connecting to a cluster, this application uses the following default information to connect to a cluster with Camunda's Identity as an identity provider option:
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ * */
+
+public class AuthorizationProvider {
+    public static void main(final String[] args) {
+
+    final String ZEEBE_ADDRESS = "localhost:26500";
+    final String ZEEBE_CLIENT_ID = "zeebe";
+    final String ZEEBE_CLIENT_SECRET = "zecret";
+    final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
+    final String ZEEBE_AUTHORIZATION_SERVER_URL = "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token";
+
+
+
+
+    /*
+
+    // Connect to local deployment. Assumes that authentication is disabled.
+    final ZeebeClientBuilder zeebeClientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(ZEEBE_ADDRESS).usePlaintext();
+    final ZeebeClient client = zeebeClientBuilder.build();
+
+     */
+
+
+
+    /*
+
+    //Connect to local deployment with Bearer token in header. Assumes that authentication is enabled.
+    final ZeebeClientBuilder zeebeClientBuilder = ZeebeClient.newClientBuilder().credentialsProvider(new MyCredentialsProvider()).gatewayAddress(ZEEBE_ADDRESS).usePlaintext();
+    final ZeebeClient client = zeebeClientBuilder.build();
+
+   */
+
+        //Connect to a local deployment with OAuthCredentialsProvider with Identity. Assumes authentication is enabled.
+
+    final OAuthCredentialsProvider provider =
+            new OAuthCredentialsProviderBuilder()
+                    .clientId(ZEEBE_CLIENT_ID)
+                    .clientSecret(ZEEBE_CLIENT_SECRET)
+                    .audience(ZEEBE_CLIENT_AUDIENCE)
+                    .authorizationServerUrl(ZEEBE_AUTHORIZATION_SERVER_URL)
+                    .build();
+
+    final ZeebeClient client =
+            new ZeebeClientBuilderImpl()
+                    .gatewayAddress(ZEEBE_ADDRESS).usePlaintext()
+                    .credentialsProvider(provider)
+                    .build();
+
+
+
+        System.out.println("Zeebe topology: " + client.newTopologyRequest().send().join().toString());
+
+}
+}

--- a/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/authorization/MyCredentialsProvider.java
+++ b/zeebe-client-plain-java/src/main/java/io/camunda/zeebe/example/authorization/MyCredentialsProvider.java
@@ -1,0 +1,26 @@
+package io.camunda.zeebe.example.authorization;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.camunda.zeebe.client.CredentialsProvider;
+
+public class MyCredentialsProvider implements CredentialsProvider{
+
+    /**
+     * Adds a token to the Authorization header of a gRPC call.
+     */
+    @Override
+    public void applyCredentials(final Metadata headers) {
+        final Metadata.Key<String> authHeaderkey = Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+        headers.put(authHeaderkey, "Bearer token");
+    }
+
+    /**
+     * Retries request if it failed with a timeout.
+     */
+    @Override
+    public boolean shouldRetryRequest(final Throwable throwable) {
+        return ((StatusRuntimeException) throwable).getStatus() == Status.DEADLINE_EXCEEDED;
+    }
+}


### PR DESCRIPTION
With Camunda Platform 8.2, we released Zeebe gRPC authentication -> https://docs.camunda.io/docs/next/self-managed/zeebe-deployment/security/client-authorization/ 

With this PR, I added code to build a Zeebe Client with Identity provider or use of bearer token.

Refactored dependencies and bumped version of slf4j2 in pom.xml to solve issues in console.