### PR TITLE
feat: migrate twitter example to Camunda Spring SDK

### DIFF
--- a/twitter-review-java-springboot/pom.xml
+++ b/twitter-review-java-springboot/pom.xml
@@ -9,9 +9,8 @@
 
   <properties>
     <java.version>21</java.version>
-    <spring-boot.version>3.3.0</spring-boot.version>
-    <zeebe.version>8.5.10</zeebe.version>
-    <spring-zeebe.version>8.5.7</spring-zeebe.version>
+    <spring-boot.version>3.3.7</spring-boot.version>
+    <camunda.version>8.6.7</camunda.version>
     <camunda-process-test-coverage.version>2.7.0</camunda-process-test-coverage.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -29,7 +28,7 @@
      <dependency>
        <groupId>io.camunda</groupId>
        <artifactId>zeebe-bom</artifactId>
-       <version>${zeebe.version}</version>
+       <version>${camunda.version}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
@@ -43,9 +42,9 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda.spring</groupId>
-      <artifactId>spring-boot-starter-camunda</artifactId>
-      <version>${spring-zeebe.version}</version>
+      <groupId>io.camunda</groupId>
+      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+      <version>${camunda.version}</version>
     </dependency>
 
     <dependency>
@@ -54,9 +53,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda.spring</groupId>
+      <groupId>io.camunda</groupId>
       <artifactId>spring-boot-starter-camunda-test</artifactId>
-      <version>${spring-zeebe.version}</version>
+      <version>${camunda.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/twitter-review-java-springboot/src/main/java/org/camunda/community/examples/twitter/TwitterExampleApplication.java
+++ b/twitter-review-java-springboot/src/main/java/org/camunda/community/examples/twitter/TwitterExampleApplication.java
@@ -1,12 +1,10 @@
 package org.camunda.community.examples.twitter;
 
-import io.camunda.zeebe.spring.client.EnableZeebeClient;
 import io.camunda.zeebe.spring.client.annotation.Deployment;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@EnableZeebeClient
 @Deployment(resources = "classpath*:*.bpmn")
 public class TwitterExampleApplication {
 

--- a/twitter-review-java-springboot/src/main/java/org/camunda/community/examples/twitter/process/TwitterWorker.java
+++ b/twitter-review-java-springboot/src/main/java/org/camunda/community/examples/twitter/process/TwitterWorker.java
@@ -2,7 +2,8 @@ package org.camunda.community.examples.twitter.process;
 
 import io.camunda.zeebe.spring.client.annotation.JobWorker;
 import io.camunda.zeebe.spring.client.annotation.VariablesAsType;
-import io.camunda.zeebe.spring.client.exception.ZeebeBpmnError;
+import io.camunda.zeebe.spring.common.exception.ZeebeBpmnError;
+import java.util.Map;
 import org.camunda.community.examples.twitter.business.DuplicateTweetException;
 import org.camunda.community.examples.twitter.business.TwitterService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +19,8 @@ public class TwitterWorker {
     try {
       twitterService.tweet(variables.getTweet());
     } catch (DuplicateTweetException ex) {
-      throw new ZeebeBpmnError("duplicateMessage", "Could not post tweet, it is a duplicate.");
+      throw new ZeebeBpmnError(
+          "duplicateMessage", "Could not post tweet, it is a duplicate.", Map.of());
     }
   }
 


### PR DESCRIPTION
## Description
Migrates the twitter sample referenced in the [Development docs](https://docs.camunda.io/docs/components/best-practices/development/testing-process-definitions/#technical-setup-using-spring) to make use of the offical SDK + the sdk testing module (fork from former community sdk) released with the 8.6.7 patch.

Closes https://github.com/camunda/camunda/issues/26429

## Additional context
<!--- Why is this change needed? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New example (non-breaking change which adds functionality to an extension)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
<!--- Please review the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code is formatted by spotless
- [ ] I have added at least one meaningful test to assert the behaviour of the example.
- [ ] I have created documentation that informs about the purpose, the functionality and how to setup the example
- [ ] I have added a build job for my example to `.github/workflows/build.yaml`
