### PR TITLE
feat: migrate async-task example to Camunda Spring SDK

### DIFF
--- a/async-service-task/pom.xml
+++ b/async-service-task/pom.xml
@@ -12,7 +12,7 @@
     <java.version>17</java.version>
     <spring-boot.version>3.3.7</spring-boot.version>
     <camunda-process-test-coverage.version>2.1.0</camunda-process-test-coverage.version>
-    <camunda.version>8.6.7-rc1</camunda.version>
+    <camunda.version>8.6.7</camunda.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/async-service-task/pom.xml
+++ b/async-service-task/pom.xml
@@ -10,9 +10,9 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.3.0</spring-boot.version>
+    <spring-boot.version>3.3.7</spring-boot.version>
     <camunda-process-test-coverage.version>2.1.0</camunda-process-test-coverage.version>
-    <spring-zeebe.version>8.5.7</spring-zeebe.version>
+    <camunda.version>8.6.7-rc1</camunda.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -32,18 +32,23 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.camunda.spring</groupId>
-      <artifactId>spring-boot-starter-camunda</artifactId>
-      <version>${spring-zeebe.version}</version>
+      <groupId>io.camunda</groupId>
+      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+      <version>${camunda.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.camunda.spring</groupId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>spring-boot-starter-camunda-test</artifactId>
-      <version>${spring-zeebe.version}</version>
+      <version>${camunda.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Description

Upcoming 8.6 patch will include the sdk test modules, thus we can migrate fully to it.

## Additional context
<!--- Why is this change needed? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New example (non-breaking change which adds functionality to an extension)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
<!--- Please review the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code is formatted by spotless
- [ ] I have added at least one meaningful test to assert the behaviour of the example.
- [ ] I have created documentation that informs about the purpose, the functionality and how to setup the example
- [ ] I have added a build job for my example to `.github/workflows/build.yaml`
