### PR TITLE
deps: update parallel-operations to camunda 8.6

### DIFF
--- a/parallel-operations/pom.xml
+++ b/parallel-operations/pom.xml
@@ -11,6 +11,8 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
+    <spring-boot.version>3.3.7</spring-boot.version>
+    <camunda.version>8.6.7</camunda.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -26,34 +28,42 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-bom</artifactId>
-        <version>8.6.6</version>
+        <version>${camunda.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.3.0</version>
+        <version>${spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>io.camunda.spring</groupId>
-        <artifactId>spring-boot-starter-camunda</artifactId>
-        <version>8.5.15</version>
+        <groupId>io.camunda</groupId>
+        <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+        <version>${camunda.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.camunda.spring</groupId>
+        <groupId>io.camunda</groupId>
         <artifactId>spring-boot-starter-camunda-test-testcontainer</artifactId>
-        <version>8.5.15</version>
+        <version>${camunda.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
     <dependency>
-      <groupId>io.camunda.spring</groupId>
-      <artifactId>spring-boot-starter-camunda</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+      <exclusions>
+        <!-- this needs to be excluded to avoid a conflict with the transitive shaded jar dependency used by
+             camunda-bpm-spring-boot-starter-webapp -->
+        <exclusion>
+          <groupId>org.camunda.feel</groupId>
+          <artifactId>feel-engine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.camunda.bpm.springboot</groupId>
@@ -73,7 +83,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda.spring</groupId>
+      <groupId>io.camunda</groupId>
       <artifactId>spring-boot-starter-camunda-test-testcontainer</artifactId>
       <scope>test</scope>
     </dependency>

--- a/parallel-operations/src/main/resources/application.yaml
+++ b/parallel-operations/src/main/resources/application.yaml
@@ -3,5 +3,3 @@ camunda:
     admin-user:
       id: demo
       password: demo
-  client:
-    mode: selfmanaged

--- a/parallel-operations/src/main/resources/application.yaml
+++ b/parallel-operations/src/main/resources/application.yaml
@@ -4,4 +4,4 @@ camunda:
       id: demo
       password: demo
   client:
-    mode: simple
+    mode: selfmanaged


### PR DESCRIPTION
## Description

One more updated, there was a conflict here relating to the feel engine deps from Camunda 7 (which depends on a shaded jar) and 8. Could resolve it by excluding the non shaded jar from the camunda 8 deps.

## Additional context
<!--- Why is this change needed? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New example (non-breaking change which adds functionality to an extension)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
<!--- Please review the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code is formatted by spotless
- [ ] I have added at least one meaningful test to assert the behaviour of the example.
- [ ] I have created documentation that informs about the purpose, the functionality and how to setup the example
- [ ] I have added a build job for my example to `.github/workflows/build.yaml`
