### PR TITLE
feat: apply convention-over-configuration to Spring Boot job workers

### DIFF
--- a/async-service-task/src/main/java/com/camunda/consulting/AsyncJobWorker.java
+++ b/async-service-task/src/main/java/com/camunda/consulting/AsyncJobWorker.java
@@ -4,9 +4,11 @@ import com.camunda.consulting.AsyncService.TransactionResult;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.spring.client.annotation.JobWorker;
+import io.camunda.zeebe.spring.client.annotation.Variable;
 import java.time.Duration;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -23,25 +25,19 @@ public class AsyncJobWorker {
   }
 
   @JobWorker(autoComplete = false, type = "async-job")
-  public void handle(ActivatedJob job) {
-    String transactionId = getOrCreateTransactionId(job);
-    asyncService.startTransaction(transactionId);
-    TransactionResult result = asyncService.getTransactionResult(transactionId);
+  public void handle(ActivatedJob job, @Variable(name = "transactionId") @Nullable String transactionId) {
+    String txId = getOrCreateTransactionId(job, transactionId);
+    asyncService.startTransaction(txId);
+    TransactionResult result = asyncService.getTransactionResult(txId);
     if (result.complete()) {
       completeJob(job, result.result());
       // this comes afterward as it could be considered optional
-      asyncService.completeTransaction(transactionId);
+      asyncService.completeTransaction(txId);
     } else {
       delayJob(job, Duration.ofSeconds(30));
     }
   }
 
-  /**
-   * Completes the job with the given result
-   *
-   * @param job the job to complete
-   * @param result the result to submit
-   */
   private void completeJob(ActivatedJob job, String result) {
     zeebeClient
         .newCompleteCommand(job)
@@ -50,26 +46,13 @@ public class AsyncJobWorker {
         .join();
   }
 
-  /**
-   * Delays the job with the given backoff
-   *
-   * @param job the job to delay
-   * @param backoff the backoff after which the job will be available again
-   */
   private void delayJob(ActivatedJob job, Duration backoff) {
     zeebeClient.newFailCommand(job).retries(job.getRetries()).retryBackoff(backoff).send().join();
   }
 
-  /**
-   * Checks if a transaction id is already present and creates one if not
-   *
-   * @param job the job that requires the transaction id
-   * @return the transaction id from the job or a created one that is saved to the job now
-   */
-  private String getOrCreateTransactionId(ActivatedJob job) {
-
-    if (!job.getVariablesAsMap().containsKey(TRANSACTION_ID_VAR_NAME)) {
-      // there is no transaction id present yet, better set one (and send it to zeebe)
+  private String getOrCreateTransactionId(ActivatedJob job, @Nullable String existingId) {
+    if (existingId == null) {
+      // no transaction id present yet — create one and persist it to the job scope
       String transactionId = asyncService.createTransactionId();
       zeebeClient
           .newSetVariablesCommand(job.getElementInstanceKey())
@@ -79,6 +62,6 @@ public class AsyncJobWorker {
           .join();
       return transactionId;
     }
-    return (String) job.getVariablesAsMap().get(TRANSACTION_ID_VAR_NAME);
+    return existingId;
   }
 }

--- a/large-multi-instance-example/src/main/java/com/camunda/consulting/worker/multi_instance/SimpleMultiInstanceWorker.java
+++ b/large-multi-instance-example/src/main/java/com/camunda/consulting/worker/multi_instance/SimpleMultiInstanceWorker.java
@@ -3,6 +3,7 @@ package com.camunda.consulting.worker.multi_instance;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.spring.client.annotation.JobWorker;
+import io.camunda.zeebe.spring.client.annotation.Variable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,12 +31,8 @@ public class SimpleMultiInstanceWorker {
   }
 
   @JobWorker
-  public Map<String, Object> elementCreation(JobClient client, ActivatedJob job) {
-    Map<String, Object> inputVars = job.getVariablesAsMap();
-    LOG.info("Creating element: {}", inputVars);
-    Map<String, Object> outputVars = new HashMap<>();
-    String element = (String) inputVars.get("element");
-    outputVars.put("result", (int) element.charAt(0));
-    return outputVars;
+  public Map<String, Object> elementCreation(@Variable String element) {
+    LOG.info("Creating element: {}", element);
+    return Map.of("result", (int) element.charAt(0));
   }
 }

--- a/payment-example-process-application/src/main/java/com/camunda/consulting/web_shop_process_app/worker/CreditCardHandler.java
+++ b/payment-example-process-application/src/main/java/com/camunda/consulting/web_shop_process_app/worker/CreditCardHandler.java
@@ -2,9 +2,10 @@ package com.camunda.consulting.web_shop_process_app.worker;
 
 import com.camunda.consulting.web_shop_process_app.service.CreditCardExpiredException;
 import com.camunda.consulting.web_shop_process_app.service.CreditCardService;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.worker.JobClient;
-import io.camunda.zeebe.spring.client.annotation.JobWorker;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.annotation.Variable;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,16 +22,17 @@ public class CreditCardHandler {
     this.creditCardService = creditCardService;
   }
 
-  @JobWorker(type = "creditCardCharging", autoComplete = false)
-  public void handle(JobClient client, ActivatedJob job) {
+  @JobWorker(autoComplete = false)
+  public void creditCardCharging(
+      JobClient client,
+      ActivatedJob job,
+      @Variable String cardNumber,
+      @Variable String cvc,
+      @Variable String expiryDate,
+      @Variable Double openAmount) {
     LOG.info("Handling credit card payment for process instance {}", job.getProcessInstanceKey());
-    Map<String, Object> variables = job.getVariablesAsMap();
-    String cardNumber = (String) variables.get("cardNumber");
-    String cvc = (String) variables.get("cvc");
-    String expiryDate = (String) variables.get("expiryDate");
-    Double amount = Double.valueOf(variables.get("openAmount").toString());
     try {
-      creditCardService.chargeAmount(cardNumber, cvc, expiryDate, amount);
+      creditCardService.chargeAmount(cardNumber, cvc, expiryDate, openAmount);
       client.newCompleteCommand(job).send();
     } catch (CreditCardExpiredException e) {
       LOG.info("Credit card payment failed: {}", e.getLocalizedMessage());

--- a/payment-example-process-application/src/main/java/com/camunda/consulting/web_shop_process_app/worker/CustomerCreditHandler.java
+++ b/payment-example-process-application/src/main/java/com/camunda/consulting/web_shop_process_app/worker/CustomerCreditHandler.java
@@ -1,8 +1,8 @@
 package com.camunda.consulting.web_shop_process_app.worker;
 
 import com.camunda.consulting.web_shop_process_app.service.CustomerService;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.spring.client.annotation.JobWorker;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.annotation.Variable;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,16 +19,13 @@ public class CustomerCreditHandler {
     this.customerService = customerService;
   }
 
-  @JobWorker(type = "customerCreditHandling")
-  public Map<String, Object> handle(ActivatedJob job) {
-    LOG.info("Handling customer credit for process instance {}", job.getProcessInstanceKey());
-
-    Map<String, Object> variables = job.getVariablesAsMap();
-    String customerId = (String) variables.get("customerId");
-    Double amount = Double.valueOf(variables.get("orderTotal").toString());
+  @JobWorker
+  public Map<String, Object> customerCreditHandling(
+      @Variable String customerId, @Variable Double orderTotal) {
+    LOG.info("Handling customer credit for customerId {}", customerId);
 
     Double customerCredit = customerService.getCustomerCredit(customerId);
-    Double remainingAmount = customerService.deductCredit(customerId, amount, customerCredit);
+    Double remainingAmount = customerService.deductCredit(customerId, orderTotal, customerCredit);
 
     return Map.of("customerCredit", customerCredit, "remainingAmount", remainingAmount);
   }

--- a/twitter-review-java-springboot/src/main/java/org/camunda/community/examples/twitter/process/TwitterWorker.java
+++ b/twitter-review-java-springboot/src/main/java/org/camunda/community/examples/twitter/process/TwitterWorker.java
@@ -1,9 +1,8 @@
 package org.camunda.community.examples.twitter.process;
 
-import io.camunda.zeebe.spring.client.annotation.JobWorker;
-import io.camunda.zeebe.spring.client.annotation.VariablesAsType;
-import io.camunda.zeebe.spring.common.exception.ZeebeBpmnError;
-import java.util.Map;
+import io.camunda.client.CamundaError;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.annotation.VariablesAsType;
 import org.camunda.community.examples.twitter.business.DuplicateTweetException;
 import org.camunda.community.examples.twitter.business.TwitterService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,17 +13,16 @@ public class TwitterWorker {
 
   @Autowired private TwitterService twitterService;
 
-  @JobWorker(type = "publish-tweet")
-  public void handleTweet(@VariablesAsType TwitterProcessVariables variables) throws Exception {
+  @JobWorker
+  public void publishTweet(@VariablesAsType TwitterProcessVariables variables) throws Exception {
     try {
       twitterService.tweet(variables.getTweet());
     } catch (DuplicateTweetException ex) {
-      throw new ZeebeBpmnError(
-          "duplicateMessage", "Could not post tweet, it is a duplicate.", Map.of());
+      throw CamundaError.bpmnError("duplicateMessage", "Could not post tweet, it is a duplicate.");
     }
   }
 
-  @JobWorker(type = "send-rejection")
+  @JobWorker
   public void sendRejection(@VariablesAsType TwitterProcessVariables variables) throws Exception {
     // same thing as above, do data transformation and delegate to real business code / service
   }

--- a/twitter-review-java-springboot/src/main/resources/twitter.bpmn
+++ b/twitter-review-java-springboot/src/main/resources/twitter.bpmn
@@ -27,7 +27,7 @@
     <sequenceFlow id="sequence_flow_tweet_reviewed" name="" sourceRef="user_task_review_tweet" targetRef="gateway_approved" />
     <serviceTask id="service_task_send_rejection_notification" name="Send rejection notification" camunda:class="twitter.RejectionNotificationDelegate">
       <extensionElements>
-        <zeebe:taskDefinition type="send-rejection" />
+        <zeebe:taskDefinition type="sendRejection" />
       </extensionElements>
       <incoming>sequence_flow_approved_no</incoming>
       <outgoing>sequqnce_flow_rejection_sent</outgoing>
@@ -43,7 +43,7 @@
     <sequenceFlow id="sequence_flow_tweet_duplicated" name="" sourceRef="boundary_event_tweet_duplicated" targetRef="user_task_handle_duplicate" />
     <serviceTask id="service_task_publish_on_twitter" name="Publish on Twitter" camunda:delegateExpression="#{tweetPublicationDelegate}">
       <extensionElements>
-        <zeebe:taskDefinition type="publish-tweet" />
+        <zeebe:taskDefinition type="publishTweet" />
       </extensionElements>
       <incoming>sequence_flow_approved_yes</incoming>
       <outgoing>sequence_flow_tweet_published</outgoing>


### PR DESCRIPTION
## What this PR does

Applies convention-over-configuration to Spring Boot job worker examples, following the pattern described in the camunda-docs Spring Boot Starter documentation: use the method name as the job type and `@Variable` for typed parameter injection instead of manual `getVariablesAsMap()` + unsafe casts.

## Changes

**`payment-example-process-application`**
- `CustomerCreditHandler`: rename `handle()` → `customerCreditHandling()` (matches BPMN task type, so `type =` attribute can be dropped); replace `job.getVariablesAsMap()` + string cast + `Double.valueOf(...toString())` with `@Variable String customerId, @Variable Double orderTotal`
- `CreditCardHandler`: rename `handle()` → `creditCardCharging()`, drop `type = "creditCardCharging"`, add `@Variable` params for all four credit card fields

**`large-multi-instance-example`**
- `SimpleMultiInstanceWorker.elementCreation()`: remove unused `JobClient client, ActivatedJob job` parameters; inject `element` directly via `@Variable String element`

**`async-service-task`**
- `AsyncJobWorker`: fix the double `job.getVariablesAsMap()` call by injecting `transactionId` as `@Variable(name="transactionId") @Nullable String`; simplify `getOrCreateTransactionId()` to accept the already-resolved value

**`twitter-review-java-springboot`**
- `twitter.bpmn`: rename service task types `publish-tweet` → `publishTweet`, `send-rejection` → `sendRejection` (camelCase allows Java method names to match)
- `TwitterWorker`: drop `type =` attributes, rename `handleTweet()` → `publishTweet()`; migrate to `io.camunda.client.*` annotations and `CamundaError.bpmnError()`

## Why

`getVariablesAsMap()` fetches all process variables and requires unsafe casts. `@Variable` fetches only the named variables and auto-converts JSON types. Method-name-as-type removes redundant boilerplate. Both improvements make the examples align with the recommended patterns in the Camunda Spring Boot Starter documentation.

> **Note:** This PR overlaps with #1281 on the import migration for the files it touches. Merge #1281 first to minimize conflicts.